### PR TITLE
get/set CSS position on button click, not createPopup()

### DIFF
--- a/js/dashicons-picker.js
+++ b/js/dashicons-picker.js
@@ -262,9 +262,13 @@
 
 		return this.each( function () {
 
-			var button = $( this );
+			var button = $( this ),
+				offsetTop,
+				offsetLeft;
 
-			button.on( 'click.dashiconsPicker', function () {
+			button.on( 'click.dashiconsPicker', function ( e ) {
+				offsetTop = $( e.currentTarget ).offset().top;
+				offsetLeft = $( e.currentTarget ).offset().left;
 				createPopup( button );
 			} );
 
@@ -276,8 +280,8 @@
 						<ul class="dashicon-picker-list" /> \
 					</div>' )
 						.css( {
-							'top':  button.offset().top,
-							'left': button.offset().left
+							'top':  offsetTop,
+							'left': offsetLeft
 						} ),
 					list = popup.find( '.dashicon-picker-list' );
 


### PR DESCRIPTION
When using the picker on the quick edit form, the positioning was off on the popup modal due to the offset being called when the popup is created.  This was due to the the button being cloned into the quick edit form, while the original element was hidden at the bottom of the screen.  By getting the  offset value when the button is clicked we can account for the current position of the current/clicked button, not the original.  

See the attached screenshots.

Before the fix:
![off-position](https://cloud.githubusercontent.com/assets/2658127/14125993/cdbdd2dc-f5d3-11e5-9d0c-6b7072ffb381.png)

After the fix:
![on-position](https://cloud.githubusercontent.com/assets/2658127/14125994/cdbe11de-f5d3-11e5-81ce-4410dd1e8c7d.png)

