### PR TITLE
Update for jQuery 3.5*

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ function dashicons_picker_scripts() {
 add_action( 'admin_enqueue_scripts', 'dashicons_picker_scripts' );
 ```
 
-Together, the 2 files are less than 8KB. And that is unminified, which is very small indeed. And as you can see in the code above, the CSS file is dependent on 'dashicons' so that will automatically include the stylesheets needed to view the dashicons font.
+Together, the 2 files are less than 8kB. And that is unminified, which is very small indeed. And as you can see in the code above, the CSS file is dependent on 'dashicons' so that will automatically include the stylesheets needed to view the dashicons font.
 
 Then in your HTML, give the button a class or "dashicons-picker" and include a data-target attribute which stores the selector to the textbox:
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ First, include both the dashicons-picker.css and dashicons-picker.js files:
 ```php
 function dashicons_picker_scripts() {
 	$css = plugin_dir_url( __FILE__ ) . 'css/dashicons-picker.css';
-    wp_enqueue_style( 'dashicons-picker', $css, array( 'dashicons' ), '1.0' );
+	wp_enqueue_style( 'dashicons-picker', $css, array( 'dashicons' ), '1.0' );
 
 	$js = plugin_dir_url( __FILE__ ) . 'js/dashicons-picker.js';
 	wp_enqueue_script( 'dashicons-picker', $js, array( 'jquery' ), '1.0' );

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ function dashicons_picker_scripts() {
 	$js = plugin_dir_url( __FILE__ ) . 'js/dashicons-picker.js';
 	wp_enqueue_script( 'dashicons-picker', $js, array( 'jquery' ), '1.0' );
 }
-add_action( 'admin_enqueue_scripts', 'dashicons_picker_scripts' );</pre>
+add_action( 'admin_enqueue_scripts', 'dashicons_picker_scripts' );
 ```
 
 Together, the 2 files are less than 8KB. And that is unminified, which is very small indeed. And as you can see in the code above, the CSS file is dependent on 'dashicons' so that will automatically include the stylesheets needed to view the dashicons font.

--- a/js/dashicons-picker.js
+++ b/js/dashicons-picker.js
@@ -5,7 +5,7 @@
  */
 
 ( function ( $ ) {
-
+	'use strict';
 	/**
 	 *
 	 * @returns {void}
@@ -342,21 +342,22 @@
 
 				var target = $( button.data( 'target' ) ),
 					preview = $( button.data( 'preview' ) ),
-					popup  = $( '<div class="dashicon-picker-container"> \
-						<div class="dashicon-picker-control"></div> \
-						<ul class="dashicon-picker-list"></ul> \
-					</div>' )
-						.css( {
-							'top':  offsetTop,
-							'left': offsetLeft
-						} ),
+					popup  = $( '<div class="dashicon-picker-container">' +
+						'<div class="dashicon-picker-control"></div>' +
+						'<ul class="dashicon-picker-list"></ul>' +
+					'</div>' ).css( {
+						'top':  offsetTop,
+						'left': offsetLeft
+					} ),
 					list = popup.find( '.dashicon-picker-list' );
 
 				for ( var i in icons ) {
-					list.append( '<li data-icon="' + icons[i] + '"><a href="#" title="' + icons[i] + '"><span class="dashicons dashicons-' + icons[i] + '"></span></a></li>' );
-				};
+					if ( icons.hasOwnProperty(i) ) {
+						list.append('<li data-icon="' + icons[i] + '"><a href="#" title="' + icons[i] + '"><span class="dashicons dashicons-' + icons[i] + '"></span></a></li>');
+					}
+				}
 
-				$( 'a', list ).click( function ( e ) {
+				$( 'a', list ).on( 'click', function ( e ) {
 					e.preventDefault();
 					var title = $( this ).attr( 'title' );
 					target.val( 'dashicons-' + title );
@@ -368,13 +369,13 @@
 
 				var control = popup.find( '.dashicon-picker-control' );
 
-				control.html( '<a data-direction="back" href="#"> \
-					<span class="dashicons dashicons-arrow-left-alt2"></span></a> \
-					<input type="text" class="" placeholder="Search" /> \
-					<a data-direction="forward" href="#"><span class="dashicons dashicons-arrow-right-alt2"></span></a>'
+				control.html( '<a data-direction="back" href="#">' +
+					'<span class="dashicons dashicons-arrow-left-alt2"></span></a>' +
+					'<input type="text" class="" placeholder="Search" />' +
+					'<a data-direction="forward" href="#"><span class="dashicons dashicons-arrow-right-alt2"></span></a>'
 				);
 
-				$( 'a', control ).click( function ( e ) {
+				$( 'a', control ).on( 'click', function ( e ) {
 					e.preventDefault();
 					if ( $( this ).data( 'direction' ) === 'back' ) {
 						$( 'li:gt(' + ( icons.length - 26 ) + ')', list ).prependTo( list );
@@ -400,7 +401,7 @@
 					}
 				} );
 
-				$( document ).bind( 'mouseup.dashicons-picker', function ( e ) {
+				$( document ).on( 'mouseup.dashicons-picker', function ( e ) {
 					if ( ! popup.is( e.target ) && popup.has( e.target ).length === 0 ) {
 						removePopup();
 					}
@@ -409,7 +410,7 @@
 
 			function removePopup() {
 				$( '.dashicon-picker-container' ).remove();
-				$( document ).unbind( '.dashicons-picker' );
+				$( document ).off( '.dashicons-picker' );
 			}
 		} );
 	};


### PR DESCRIPTION
Thanks again for this picker, because I use them in two projects, like the helper for all Plugin writers - https://github.com/bueltge/wordpress-admin-style
Now I'm sitting on several updates on another plugin to use it after the change from the WordPress core to the last jQuery version. Several functions are deprecated, so also in your library. Here is the update, that it works with jQuery 3.5 and bigger. Also, small changes on the type of EOL for longer strings. 
The changes on the readme remove a wrong `pre` tag.

Best.