### PR TITLE
Fix games typo

### DIFF
--- a/js/dashicons-picker.js
+++ b/js/dashicons-picker.js
@@ -303,7 +303,7 @@
 			'airplane',
 			'car',
 			'calculator',
-			'ames',
+			'games',
 			'printer',
 			'beer',
 			'coffee',


### PR DESCRIPTION
I noticed a typo in the icons array for the games icon: `ames` instead of `games`